### PR TITLE
Add SQLite database setup script using SQLAlchemy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # hands-on
+
+## Database Setup
+
+Install dependencies:
+
+```
+pip install -r requirements.txt
+```
+
+Create the SQLite database and tables:
+
+```
+python db_setup.py
+```

--- a/db_setup.py
+++ b/db_setup.py
@@ -1,0 +1,21 @@
+from sqlalchemy import create_engine, Column, Integer, String, MetaData, Table
+
+DATABASE_URL = "sqlite:///example.db"
+engine = create_engine(DATABASE_URL)
+
+metadata = MetaData()
+
+users_table = Table(
+    "users", metadata,
+    Column("id", Integer, primary_key=True),
+    Column("name", String, nullable=False),
+)
+
+
+def create_tables():
+    metadata.create_all(engine)
+
+
+if __name__ == "__main__":
+    create_tables()
+    print("Database and tables created.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+SQLAlchemy>=2.0


### PR DESCRIPTION
## Summary
- add SQLAlchemy requirements
- add SQLite database setup script creating a simple `users` table
- document how to install dependencies and run the setup script

## Testing
- `pip install SQLAlchemy` *(fails: Tunnel connection failed: 403 Forbidden)*
- `python db_setup.py` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `python -m py_compile db_setup.py`

------
https://chatgpt.com/codex/tasks/task_b_68bbd296afa48322a466b68b6fa134d3