### PR TITLE
Add FastAPI submit endpoint with SQLite storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,23 @@
 ## Database Setup
 
 Install dependencies:
-
 ```
 pip install -r requirements.txt
 ```
 
 Create the SQLite database and tables:
-
 ```
 python db_setup.py
+```
+
+## API
+
+Run the FastAPI application:
+```
+uvicorn app:app
+```
+
+Submit data to the API:
+```
+curl -X POST -H "Content-Type: application/json" -d "{\"name\": \"Alice\"}" http://localhost:8000/api/submit
 ```

--- a/app.py
+++ b/app.py
@@ -1,0 +1,14 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+from db_setup import engine, users_table
+
+app = FastAPI()
+
+class UserIn(BaseModel):
+    name: str
+
+@app.post("/api/submit")
+async def submit(user: UserIn):
+    with engine.begin() as conn:
+        conn.execute(users_table.insert().values(name=user.name))
+    return {"message": "User submitted"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 SQLAlchemy>=2.0
+fastapi
+uvicorn


### PR DESCRIPTION
## Summary
- add FastAPI app with `/api/submit` endpoint inserting submitted names into SQLite
- expand dependencies with FastAPI and Uvicorn and document API usage

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement SQLAlchemy>=2.0)*
- `python db_setup.py` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `python -m py_compile app.py`
- `python -m py_compile db_setup.py`

------
https://chatgpt.com/codex/tasks/task_b_68bbd793080483229597ff6f9566a042